### PR TITLE
Edit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ cd PartielsPy
 - Linux, MacOS
 ```
 .venv/bin/python3 -m pip install sphinx
-sphinx-apidoc -o ./docs ./src/PartielsPy ./src/PartielsPy/templates/*
+sphinx-apidoc -o ./docs ./src/PartielsPy ./src/PartielsPy/templates/* --private --separate --force --no-toc
 sphinx-build -b html ./docs ./docs/_build/html
 ```
 - Windows
 ```
 .venv\Scripts\python.exe -m pip install sphinx
-sphinx-apidoc -o ./docs ./src/PartielsPy --force --no-toc --exclude-pattern=**/templates/**
+sphinx-apidoc -o ./docs ./src/PartielsPy --exclude-pattern=**/templates/** --private --separate --force --no-toc
 sphinx-build -b html ./docs ./docs/_build/html
 ```
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to PartielsPy's documentation!
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: API Reference:
 
-   modules
+   PartielsPy.partiels
+   PartielsPy.export_configs


### PR DESCRIPTION
Edit docs/index.rst to avoid Partiels class duplicate in generated doc.
Edit the README: add extra arguments in sphinx command line.

A warning is triggered during the build because the PartielsPy.rst is excluded on purpose.
The only ways to avoid this warning are:
 -remove the PartielsPy.rst before launching the build command
        .a line to do so could be added in the README.
        .the .rst files generated could be includes in the github repo so the user does not a have to generate them and remove the extra one.
 -edit the index.rst to include it (resulting a duplicate of the class in the generated doc).